### PR TITLE
Support date_text input

### DIFF
--- a/src/date.hooks.js
+++ b/src/date.hooks.js
@@ -55,63 +55,79 @@ function date_assemble_form_state_into_field(entity_type, bundle, form_state_val
         result.timezone = timezone;
       }
 
-      $.each(field.settings.granularity, function(grain, value) {
+      function _date_set_attribute_on_value(grain, value) {
 
-        var date = null;
+        var d = null;
         if (_value == 'value') {
-          date = new Date(parts[0]);
+          d = new Date(parts[0]);
           if (have_item) {
             var offset = parseInt(form.elements[field.field_name][langcode][delta].item.offset);
             if (offset) { result.offset = offset; }
             if (date_apple_device() && offset) {
-              date = new Date(date.toUTCString());
-              date = date.getTime() / 1000;
-              date -= parseInt(offset);
-              date = new Date(date * 1000);
+              d = new Date(d.toUTCString());
+              d = d.getTime() / 1000;
+              d -= parseInt(offset);
+              d = new Date(d * 1000);
             }
           }
         }
         else if (_value == 'value2') {
-          date = new Date(parts[1]);
+          d = new Date(parts[1]);
           if (have_item) {
             var offset2 = parseInt(form.elements[field.field_name][langcode][delta].item.offset2);
             if (offset2) { result.offset2 = offset2; }
             if (date_apple_device() && offset2) {
-              date = new Date(date.toUTCString());
-              date = date.getTime() / 1000;
-              date -= parseInt(offset2);
-              date = new Date(date * 1000);
+              d = new Date(d.toUTCString());
+              d = d.getTime() / 1000;
+              d -= parseInt(offset2);
+              d = new Date(d * 1000);
             }
           }
         }
 
-        if (value) {
-          switch (grain) {
-            case 'year':
-              result[_value].year = date.getFullYear();
-              break;
-            case 'month':
-              result[_value].month = parseInt(date.getMonth()) + 1;
-              break;
-            case 'day':
-              result[_value].day = parseInt(date.getDate());
-              break;
-            case 'hour':
-              result[_value].hour = parseInt(date.getHours());
-              if (!date_military(instance)) {
-                if (result[_value].hour >= 12) {
-                  result[_value].hour = result[_value].hour % 12;
-                  result[_value].ampm = 'pm';
+        if (instance.widget.type == 'date_text') {
+          result[_value].date = date(instance.widget.settings.input_format, d);
+          // Support seconds.
+          result[_value].date = result[_value].date.replace("s", d.getSeconds());
+        }
+        else {
+           // instance.widget.type == 'date_select'.
+          if (value) {
+            switch (grain) {
+              case 'year':
+                result[_value].year = date.getFullYear();
+                break;
+              case 'month':
+                result[_value].month = parseInt(date.getMonth()) + 1;
+                break;
+              case 'day':
+                result[_value].day = parseInt(date.getDate());
+                break;
+              case 'hour':
+                result[_value].hour = parseInt(date.getHours());
+                if (!date_military(instance)) {
+                  if (result[_value].hour >= 12) {
+                    result[_value].hour = result[_value].hour % 12;
+                    result[_value].ampm = 'pm';
+                  }
                 }
-              }
-              break;
-            case 'minute':
-              result[_value].minute = '' + parseInt(date.getMinutes());
-              if (result[_value].minute.length == 1) { result[_value].minute = '0' + result[_value].minute; }
-              break;
+                break;
+              case 'minute':
+                result[_value].minute = '' + parseInt(date.getMinutes());
+                if (result[_value].minute.length == 1) { result[_value].minute = '0' + result[_value].minute; }
+                break;
+            }
           }
         }
-      });
+      }
+
+      if (instance.widget.type == 'date_text') {
+        _date_set_attribute_on_value(null, null);
+      }
+      else {
+         // instance.widget.type == 'date_select'.
+        $.each(field.settings.granularity, _date_set_attribute_on_value);
+      }
 
     });
 


### PR DESCRIPTION
[NOTE: This is the same as [#30](https://github.com/signalpoint/date/pull/30) but without changes to date.js and date.min.js]

This allows a date input field to be a `date_text` instead of `date_select`.  thus, all in one field rather than a bunch of date parts.
There are four types of changes in this commit:

- Two checks for the widget type, `date_text` or `date_select`
- Moved the anonymous function that fills in the result into a named function so that it can be called outside of the loop if we don't need to loop (`date_text`)
- Indentation corrected in the changed blocks of code
- Renamed the `date` variable to `d` so as not to overwrite the `date()` function which gets used