### PR TITLE
Support custom input_format

### DIFF
--- a/src/date.hooks.js
+++ b/src/date.hooks.js
@@ -86,7 +86,13 @@ function date_assemble_form_state_into_field(entity_type, bundle, form_state_val
         }
 
         if (instance.widget.type == 'date_text') {
-          result[_value].date = date(instance.widget.settings.input_format, d);
+          if (instance.widget.settings.input_format == 'custom') {
+            var format = instance.widget.settings.input_format_custom;
+          }
+          else {
+            var format = instance.widget.settings.input_format;
+          }
+          result[_value].date = date(format, d);
           // Support seconds.
           result[_value].date = result[_value].date.replace("s", d.getSeconds());
         }


### PR DESCRIPTION
The `input_format` in the widget settings is used to determine how to format what gets sent to the server.  When a custom `input_format` is used the actual format the server is expecting is in `input_format_custom`.
This patch allows for a custom `input_format`.

I needed this because I didn't want my date field collecting the time, neither through the web interface nor the app, but there is no input format without the time, so I changed the input format to custom: "m/d/Y".
I'm not sure why there's a discrepancy between the input format and the granularity.  It would be nice if they didn't need to match.